### PR TITLE
Fix array index out of bounds error on word boundaries 

### DIFF
--- a/src/org/joni/ByteCodeMachine.java
+++ b/src/org/joni/ByteCodeMachine.java
@@ -1060,7 +1060,7 @@ class ByteCodeMachine extends StackMachine {
         if (s == str) {
             if (s >= range || !enc.isMbcWord(bytes, s, end)) {opFail(); return;}
         } else if (s == end) {
-            if (!enc.isMbcWord(bytes, sprev, end)) {opFail(); return;}
+            if (s >= range || !enc.isMbcWord(bytes, sprev, end)) {opFail(); return;}
         } else {
             if (enc.isMbcWord(bytes, s, end) == enc.isMbcWord(bytes, sprev, end)) {opFail(); return;}
         }
@@ -1080,7 +1080,7 @@ class ByteCodeMachine extends StackMachine {
         if (s == str) {
             if (s < range && enc.isMbcWord(bytes, s, end)) {opFail(); return;}
         } else if (s == end) {
-            if (enc.isMbcWord(bytes, sprev, end)) {opFail(); return;}
+            if (sprev < end && enc.isMbcWord(bytes, sprev, end)) {opFail(); return;}
         } else {
             if (enc.isMbcWord(bytes, s, end) != enc.isMbcWord(bytes, sprev, end)) {opFail(); return;}
         }

--- a/test/org/joni/test/TestU8.java
+++ b/test/org/joni/test/TestU8.java
@@ -80,6 +80,8 @@ public class TestU8 extends Test {
         x2s("(?i:!\\[CDAT)", "![CDAT", 0, 6);
         x2s("(?i:\\!\\[CDAa)", "\\![CDAa", 1, 7);
         x2s("(?i:\\!\\[CDAb)", "\\![CDAb", 1, 7);
+        ns("x.*\\b", "x");
+        x2s("x.*\\B", "x", 0, 1);
     }
 
     public static void main(String[] args) throws Throwable {


### PR DESCRIPTION
This cherry picks the fix for https://github.com/prestodb/presto/issues/8711 from jruby/joni. 