### PR TITLE
Fix word boundary matching at end of line

### DIFF
--- a/src/org/joni/ByteCodeMachine.java
+++ b/src/org/joni/ByteCodeMachine.java
@@ -1060,7 +1060,7 @@ class ByteCodeMachine extends StackMachine {
         if (s == str) {
             if (s >= range || !enc.isMbcWord(bytes, s, end)) {opFail(); return;}
         } else if (s == end) {
-            if (s >= range || !enc.isMbcWord(bytes, sprev, end)) {opFail(); return;}
+            if (sprev >= end || !enc.isMbcWord(bytes, sprev, end)) {opFail(); return;}
         } else {
             if (enc.isMbcWord(bytes, s, end) == enc.isMbcWord(bytes, sprev, end)) {opFail(); return;}
         }

--- a/test/org/joni/test/TestU8.java
+++ b/test/org/joni/test/TestU8.java
@@ -82,6 +82,8 @@ public class TestU8 extends Test {
         x2s("(?i:\\!\\[CDAb)", "\\![CDAb", 1, 7);
         ns("x.*\\b", "x");
         x2s("x.*\\B", "x", 0, 1);
+
+        x2s("foo\\b", "foo", 0, 3);
     }
 
     public static void main(String[] args) throws Throwable {


### PR DESCRIPTION
This fix is cherry-picked from jruby/joni.  The regression was introduced by  https://github.com/airlift/joni/commit/64bcdcbc7bbbac100c77aad5d8091fc2b25bc540

Without this fix:
```
presto> select regexp_like('test', 'test\b');
 _col0 
-------
 false 
(1 row)
```
With this fix:
```
presto> select regexp_like('test', 'test\b');
 _col0 
-------
 true  
(1 row)
```